### PR TITLE
Allow whitespace after type separator

### DIFF
--- a/syntax/capnp.vim
+++ b/syntax/capnp.vim
@@ -10,7 +10,7 @@ endif
 syn keyword capnpKeyword using import struct union enum
 
 " Types
-syn match capnpType ":[.a-zA-Z0-9()]\+"
+syn match capnpType ":\s*[.a-zA-Z0-9()]\+"
 
 " Strings
 syn region capnpString start=/"/ skip=/\\"/ end=/"/


### PR DESCRIPTION
Change required for correct recognition of `foo @0 : Text;`.
