### PR TITLE
Allow whitespace in Type regular expression

### DIFF
--- a/syntax/capnp.vim
+++ b/syntax/capnp.vim
@@ -10,7 +10,7 @@ endif
 syn keyword capnpKeyword using import struct union enum
 
 " Types
-syn match capnpType ":[.a-zA-Z0-9()]\+"
+syn match capnpType "\s*:\s*\zs[.a-zA-Z0-9()]\+\ze"
 
 " Strings
 syn region capnpString start=/"/ skip=/\\"/ end=/"/


### PR DESCRIPTION
As opposed to #4 this regular expression also allows whitespace before the colon and it does not include the whitespace in the match.